### PR TITLE
Retain indexes when calling transform

### DIFF
--- a/sqlite_minutils/db.py
+++ b/sqlite_minutils/db.py
@@ -1871,6 +1871,28 @@ class Table(Queryable):
         sqls.append(
             "ALTER TABLE [{}] RENAME TO [{}];".format(new_table_name, self.name)
         )
+        # Re-add existing indexes
+        for index in self.indexes:
+            if index.origin not in ("pk"):
+                index_sql = self.db.execute(
+                    """SELECT sql FROM sqlite_master WHERE type = 'index' AND name = :index_name;""",
+                    {"index_name": index.name},
+                ).fetchall()[0][0]
+                assert index_sql is not None, (
+                    f"Index '{index}' on table '{self.name}' does not have a "
+                    "CREATE INDEX statement. You must manually drop this index prior to running this "
+                    "transformation and manually recreate the new index after running this transformation."
+                )
+                if keep_table:
+                    sqls.append(f"DROP INDEX IF EXISTS [{index.name}];")
+                for col in index.columns:
+                    assert col not in rename.keys() and col not in drop, (
+                        f"Index '{index.name}' column '{col}' is not in updated table '{self.name}'. "
+                        f"You must manually drop this index prior to running this transformation "
+                        f"and manually recreate the new index after running this transformation. "
+                        f"The original index sql statement is: `{index_sql}`. No changes have been applied to this table."
+                    )
+                sqls.append(index_sql)
         return sqls
 
     def extract(


### PR DESCRIPTION
Retain indexes when calling transform.

Same as PR to sqlite-utils: https://github.com/simonw/sqlite-utils/pull/634

From sqlite-utils PR:
Recreate indexes when calling transform when possible and raise an error when they cannot be retained automatically.

This resolves my initial problem: 'After creating a table with an index, if you add a foreign key constraint to the table it drops existing non-related indexes.'

GH Issue: https://github.com/simonw/sqlite-utils/issues/633

My explanation, thoughts and reasoning:

I think it is best to try and preserve existing indexes and fail loudly if they are unable to be recreated automatically. At the very least I believe you should be warned if they are not going to be recreated.

Below is my proposed solution with code:

If a table is kept it will automatically drop the original index. To be able to create the index on the new table using the original CREATE INDEX statement the original index must be dropped. I think it's a reasonable default for the 'kept' table to lose its indexes. I suspect the most common reason to keep the original table is for 'backup' purposes. It would also be difficult to automatically create updated CREATE INDEX statements for the kept renamed table where the statements are more complicated.

If a column exists in the original index but not in the new table, you should have to manually recreate the index as desired. In complicated CREATE INDEX statements it is difficult to automatically replace or remove columns correctly. Failing before any operations have been completed is desired because it allows you to know there will be a problem prior to the SQL statements being executed allowing you to collect the required information required to manually update the indexes prior to any actions taking place as well as not leaving your database in a potentially invalid state.