### PR TITLE
Adding __contains__ to table

### DIFF
--- a/sqlite_minutils/db.py
+++ b/sqlite_minutils/db.py
@@ -1420,6 +1420,18 @@ class Table(Queryable):
         "Does this table use ``rowid`` for its primary key (no other primary keys are specified)?"
         return not any(column for column in self.columns if column.is_pk)
 
+    def __contains__(self, pk_values: Union[list, tuple, str, int]) -> bool:
+        """
+        Does a row with the specified primary key value exist in this table?
+
+        :param pk_values: A single value, or a tuple of values for tables that have a compound primary key
+        """
+        try:
+            self.get(pk_values)
+            return True
+        except NotFoundError:
+            return False
+
     def get(self, pk_values: Union[list, tuple, str, int]) -> dict:
         """
         Return row (as dictionary) for the specified primary key.


### PR DESCRIPTION
# Add support for `in` to Tables

It would be nice to be able to do `if "user1" in users:`. This PR adds a `__contains__` method to Table to support this.

## To make some test data

```python
# Make the fake data
import sqlite3

# Connect to the database (it will be created if it doesn't exist)
conn = sqlite3.connect('test_in.db')

# Create a cursor object
cursor = conn.cursor()

# Single Primary Key Setup
cursor.execute('''
CREATE TABLE IF NOT EXISTS user_counts (
    name TEXT PRIMARY KEY,
    count INTEGER
)
''')

# Composite Primary Key Setup (use this instead if you prefer)
cursor.execute('''
CREATE TABLE IF NOT EXISTS user_counts_compound (
    name TEXT,
    date TEXT,
    count INTEGER,
    PRIMARY KEY (name, date)
)
''')

# Insert data for single primary key setup
cursor.execute("INSERT INTO user_counts (name, count) VALUES ('user1', 0)")
cursor.execute("INSERT INTO user_counts (name, count) VALUES ('user2', 0)")

# Insert data for composite primary key setup
cursor.execute("INSERT INTO user_counts_compound (name, date, count) VALUES ('user1', '2023-08-14', 0)")
cursor.execute("INSERT INTO user_counts_compound (name, date, count) VALUES ('user2', '2023-08-14', 0)")

# Commit the changes
conn.commit()

# Close the connection
conn.close()
```

### To sanity-check

```python
from sqlite_minutils.db import Database

db = Database('test_in.db')

user_counts = db.table('user_counts')

compound_key = db.table('user_counts_compound')

# Single primary key test
if 'user1' in user_counts:
    print("Pass: Single key test")

if 'user3' in user_counts:
    print("Fail: Single key test")
else:
    print("Success: Single key test")

# Composite primary key test
if ('user1', '2023-08-14') in user_counts:
    print("Success: Composite key test")

if ('user1', '2023-08-15') in user_counts:
    print("Fail: Composite key test")
else:
    print("Success: Composite key test")

if ('user3', '2023-08-14') in user_counts:
    print("Fail: Composite key test")
else:
    print("Success: Composite key test")
```