### PR TITLE
Correct `Database.create_table` to support transforms.

### DIFF
--- a/sqlite_minutils/db.py
+++ b/sqlite_minutils/db.py
@@ -918,7 +918,7 @@ class Database:
         """
         # Transform table to match the new definition if table already exists:
         if self[name].exists():
-            if ignore:
+            if ignore and not transform:
                 return cast(Table, self[name])
             elif replace:
                 self[name].drop()


### PR DESCRIPTION
By default the `Fastlite.Database.create()` method passes in the value of `True`. Because of this, the `Fastlite.Database.create(Thing, transform=True) method will never be reached unless this change (or an analogue) is made.