### PR TITLE
Cleaner error handling on offset without limit

### DIFF
--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -146,7 +146,7 @@
     {
      "data": {
       "text/plain": [
-       "<Table Users (name, age)>"
+       "<Table Users (id, name, age)>"
       ]
      },
      "execution_count": null,
@@ -155,7 +155,7 @@
     }
    ],
    "source": [
-    "users.create(columns=dict(name=str, age=int))\n",
+    "users.create(columns=dict(id=int, name=str, age=int))\n",
     "users"
    ]
   },
@@ -176,7 +176,7 @@
     {
      "data": {
       "text/plain": [
-       "<Table Users (name, age, pwd)>"
+       "<Table Users (id, name, age, pwd)>"
       ]
      },
      "execution_count": null,
@@ -185,7 +185,7 @@
     }
    ],
    "source": [
-    "users.create(columns=dict(name=str, age=int, pwd=str), transform=True)\n",
+    "users.create(columns=dict(id=int, name=str, age=int, pwd=str), transform=True, pk='id')\n",
     "users"
    ]
   },
@@ -199,6 +199,7 @@
      "output_type": "stream",
      "text": [
       "CREATE TABLE \"Users\" (\n",
+      "   [id] INTEGER PRIMARY KEY,\n",
       "   [name] TEXT,\n",
       "   [age] INTEGER,\n",
       "   [pwd] TEXT\n",
@@ -208,6 +209,215 @@
    ],
    "source": [
     "print(db.schema)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Queries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's add some users to query:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Table Users (id, name, age, pwd)>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "users.insert(dict(name='Raven', age=8, pwd='s3cret'))\n",
+    "users.insert(dict(name='Magpie', age=5, pwd='supersecret'))\n",
+    "users.insert(dict(name='Crow', age=12, pwd='verysecret'))\n",
+    "users.insert(dict(name='Pigeon', age=3, pwd='keptsecret'))\n",
+    "users.insert(dict(name='Eagle', age=7, pwd='s3cr3t'))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A simple unfiltered select can be executed using `rows` property on the table object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<generator object Queryable.rows_where>"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "users.rows"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's iterate over that generator to see the results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 1, 'name': 'Raven', 'age': 8, 'pwd': 's3cret'},\n",
+       " {'id': 2, 'name': 'Magpie', 'age': 5, 'pwd': 'supersecret'},\n",
+       " {'id': 3, 'name': 'Crow', 'age': 12, 'pwd': 'verysecret'},\n",
+       " {'id': 4, 'name': 'Pigeon', 'age': 3, 'pwd': 'keptsecret'},\n",
+       " {'id': 5, 'name': 'Eagle', 'age': 7, 'pwd': 's3cr3t'}]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[o for o in users.rows]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Filtering can be done via the `rows_where` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 1, 'name': 'Raven', 'age': 8, 'pwd': 's3cret'},\n",
+       " {'id': 2, 'name': 'Magpie', 'age': 5, 'pwd': 'supersecret'},\n",
+       " {'id': 3, 'name': 'Crow', 'age': 12, 'pwd': 'verysecret'},\n",
+       " {'id': 5, 'name': 'Eagle', 'age': 7, 'pwd': 's3cr3t'}]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[o for o in users.rows_where('age > 3')]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also `limit` the results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 1, 'name': 'Raven', 'age': 8, 'pwd': 's3cret'},\n",
+       " {'id': 2, 'name': 'Magpie', 'age': 5, 'pwd': 'supersecret'}]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[o for o in users.rows_where('age > 3', limit=2)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `offset` keyword can be combined with the `limit` keyword."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 2, 'name': 'Magpie', 'age': 5, 'pwd': 'supersecret'},\n",
+       " {'id': 3, 'name': 'Crow', 'age': 12, 'pwd': 'verysecret'}]"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[o for o in users.rows_where('age > 3', limit=2, offset=1)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `offset` must be used with `limit` or raise a `ValueError`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cannot use offset without limit\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    [o for o in users.rows_where(offset=1)]\n",
+    "except ValueError as e:\n",
+    "    print(e)\n"
    ]
   }
  ],

--- a/sqlite_minutils/db.py
+++ b/sqlite_minutils/db.py
@@ -1266,8 +1266,10 @@ class Queryable:
             sql += " order by " + order_by
         if limit is not None:
             sql += " limit {}".format(limit)
+        if offset is not None and limit is None:
+            raise ValueError("Cannot use offset without limit")
         if offset is not None:
-            sql += " offset {}".format(offset)
+            sql += f" offset {offset}"
         cursor = self.db.execute(sql, tuple(where_args or []))
         columns = [c[0] for c in cursor.description]
         for row in cursor:


### PR DESCRIPTION
This PR addresses the scenario of parenthesis search from fastlite on default configuration SQLite, where OFFSET without LIMIT throws an error within SQLite. It documents this new behavior as well as basic queries used to set up context needed for the error.

A follow-up ticket is #10, which addresses this issue across the whole of sqlite-minutils. Separating out the ticket into a new action keeps the scope of this PR small. It also gives us the chance to determine if this is particular to my local installation of Python and/or sqlite.