### PR TITLE
Full-text search seems to be broken

### DIFF
--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -419,6 +419,51 @@
     "except ValueError as e:\n",
     "    print(e)\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Full-text search"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's define a table `notes` with a field called `text` and enable full-text search on this field"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "notes = Table(db, 'notes')\n",
+    "notes = notes.create(columns=dict(id=int, content=str), pk=\"id\")\n",
+    "\n",
+    "notes.enable_fts([\"content\"], create_triggers=True)\n",
+    "\n",
+    "notes.insert(dict(content=\"hello\"))\n",
+    "notes.insert(dict(content=\"world\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "From now on, we expect to be able to use full text search using `search` function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert len(list(notes.search(\"hell0\", columns=[\"content\"]))) != 0"
+   ]
   }
  ],
  "metadata": {

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -462,7 +462,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert len(list(notes.search(\"hell0\", columns=[\"content\"]))) != 0"
+    "assert len(list(notes.search(\"hello\", columns=[\"content\"]))) != 0"
    ]
   }
  ],


### PR DESCRIPTION
I am not able to use full-text search functionality at the moment. As far as I can tell, the issue coming from [detect_fts](https://github.com/simonw/sqlite-utils/blob/main/sqlite_utils/db.py#L2521-L2546) which returns `None`.

Some further investigation:

```python
import textwrap

sql = textwrap.dedent(
    """
    SELECT name FROM sqlite_master
        WHERE rootpage = 0
        AND (
            sql LIKE :like
            OR sql LIKE :like2
            OR (
                tbl_name = :table
                AND sql LIKE '%VIRTUAL TABLE%USING FTS%'
            )
        )
"""
).strip()
args = {
    "like": "%VIRTUAL TABLE%USING FTS%content=[{}]%".format(notes.name),
    "like2": '%VIRTUAL TABLE%USING FTS%content="{}"%'.format(notes.name),
    "table": notes.name,
}

# this returns []
db.execute(sql, args).fetchall()

# this returns
# [('notes',),
# ('notes_fts',),
# ('notes_fts_data',),
# ('notes_fts_idx',),
# ('notes_fts_docsize',),
# ('notes_fts_config',),
# ('notes_ai',),
# ('notes_ad',),
# ('notes_au',)]
list(db.execute("SELECT name FROM sqlite_master"))
```

`sql` for `notes_fts` looks as follows:

```
'CREATE VIRTUAL TABLE [notes_fts] USING FTS5 (\n    [content],\n    content=[notes]\n)'
```

I'm happy to submit a fix but I don't think I fully understand where the issue is