### PR TITLE
Fix wrong handling of named parameters

### DIFF
--- a/sqlite_minutils/db.py
+++ b/sqlite_minutils/db.py
@@ -431,7 +431,7 @@ class Database:
         if self._tracer:
             self._tracer(sql, parameters)
         if parameters is not None:
-            return self.conn.execute(sql, tuple(parameters))
+            return self.conn.execute(sql, parameters)
         else:
             return self.conn.execute(sql)
 


### PR DESCRIPTION
A bug in `db.q` where queries with named parameters which require a dictionary of name,value were not working.
Parameter dicts were accidentally turned to tuples of keys.