### PR TITLE
Add returning to inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@
 
 ## Use
 
+``` python
+from fastcore.utils import *
+from fastcore.test import *
+from typing import Any
+```
+
 First, import the sqlite-miniutils library. Through the use of the
 **all** attribute in our Python modules by using `import *` we only
 bring in the `Database`, `Queryable`, `Table`, `View` classes. There’s
@@ -107,7 +113,7 @@ users.insert(dict(name='Pigeon', age=3, pwd='keptsecret'))
 users.insert(dict(name='Eagle', age=7, pwd='s3cr3t'))
 ```
 
-    <Table Users (id, name, age, pwd)>
+    {'id': 5, 'name': 'Eagle', 'age': 7, 'pwd': 's3cr3t'}
 
 A simple unfiltered select can be executed using `rows` property on the
 table object.
@@ -116,7 +122,7 @@ table object.
 users.rows
 ```
 
-    <generator object Queryable.rows_where at 0x10849f6f0>
+    <generator object Queryable.rows_where>
 
 Let’s iterate over that generator to see the results:
 
@@ -169,3 +175,76 @@ except ValueError as e:
 ```
 
     Cannot use offset without limit
+
+## Transactions
+
+If you have any SQL calls outside an explicit transaction, they are
+committed instantly.
+
+To group 2 or more queries together into 1 transaction, wrap them in a
+BEGIN and COMMIT, executing ROLLBACK if an exception is caught:
+
+``` python
+users.get(1)
+```
+
+    {'id': 1, 'name': 'Raven', 'age': 8, 'pwd': 's3cret'}
+
+``` python
+db.begin()
+try:
+    users.delete([1])
+    db.execute('FNOOORD')
+    db.commit()
+except Exception as e:
+    print(e)
+    db.rollback()
+```
+
+    near "FNOOORD": syntax error
+
+Because the transaction was rolled back, the user was not deleted:
+
+``` python
+users.get(1)
+```
+
+    {'id': 1, 'name': 'Raven', 'age': 8, 'pwd': 's3cret'}
+
+Let’s do it again, but without the DB error, to check the transaction is
+successful:
+
+``` python
+db.begin()
+try:
+    users.delete([1])
+    db.commit()
+except Exception as e: db.rollback()
+```
+
+``` python
+try:
+    users.get(1)
+    print("Delete failed!")
+except: print("Delete succeeded!")
+```
+
+    Delete succeeded!
+
+## Returning
+
+sqlite-minutils is different from sqlite-utils in that write actions
+(`INSERT`, `UPDATE`, `UPSERT`) return back the record(s) they have
+affected without relying on `last_rowid`. It does this through the
+`RETURNING` SQL keyword.
+
+``` python
+user = users.insert(dict(name='Turkey', age=2, pwd='gravy'))
+user
+```
+
+    {'id': 8, 'name': 'Turkey', 'age': 2, 'pwd': 'gravy'}
+
+``` python
+test(user['name'], 'Turkey', equals)
+```

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -1,6 +1,26 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
+   "source": [
+    "#| hide\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -50,8 +70,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#| hide\n",
     "from fastcore.utils import *\n",
+    "from fastcore.test import *\n",
     "from typing import Any"
    ]
   },
@@ -233,7 +253,7 @@
     {
      "data": {
       "text/plain": [
-       "<Table Users (id, name, age, pwd)>"
+       "{'id': 5, 'name': 'Eagle', 'age': 7, 'pwd': 's3cr3t'}"
       ]
      },
      "execution_count": null,
@@ -548,11 +568,48 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Returning"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "sqlite-minutils is different from sqlite-utils in that write actions (`INSERT`, `UPDATE`, `UPSERT`) return back the record(s) they have affected without relying on `last_rowid`. It does this through the `RETURNING` SQL keyword."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 8, 'name': 'Turkey', 'age': 2, 'pwd': 'gravy'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "user = users.insert(dict(name='Turkey', age=2, pwd='gravy'))\n",
+    "user"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "test(user['name'], 'Turkey', equals)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
To support environments with users performing concurrent writes we are now using the `RETURNING` statement with inserts. 

- This PR includes a test to confirm the insert is working correctly
- `insert_chunk` now returns `List[Dict]`, before it returned `None`
- `insert_all` now returns `List[Dict]`, before it returned instances of `Table`
- `insert` now returns a `Dict`, before it returned instances of `Table`

## Questions

1. Does make sense to have `insert_chunk` and `insert_all` return generator expressions instead of [ListDict]? The latter makes sense on large loads but makes typing a little more complicated for users.
2. The PR renders out the index.ipynb to the readme, which adds documentation for transactions that was only in the notebook. Does that belong in this PR?