### PR TITLE
Add RETURNING to Table.update()

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ sqlite-minutils is different from sqlite-utils in that write actions
 affected without relying on `last_rowid`. It does this through the
 `RETURNING` SQL keyword.
 
-Testing `INSERT`, including preserving `last_pk` attribute
+Testing `INSERT`
 
 ``` python
 user = users.insert(dict(name='Turkey', age=2, pwd='gravy'))
@@ -251,7 +251,7 @@ user
 test(user['name'], 'Turkey', equals)
 ```
 
-Testing `UPDATE`, including preserving `last_pk` attribute
+Testing `UPDATE`
 
 ``` python
 user = users.insert(dict(name='Flamingo', age=12, pwd='pink'))

--- a/README.md
+++ b/README.md
@@ -238,13 +238,36 @@ sqlite-minutils is different from sqlite-utils in that write actions
 affected without relying on `last_rowid`. It does this through the
 `RETURNING` SQL keyword.
 
+Testing `INSERT`, including preserving `last_pk` attribute
+
 ``` python
 user = users.insert(dict(name='Turkey', age=2, pwd='gravy'))
 user
 ```
 
-    {'id': 8, 'name': 'Turkey', 'age': 2, 'pwd': 'gravy'}
+    {'id': 6, 'name': 'Turkey', 'age': 2, 'pwd': 'gravy'}
 
 ``` python
 test(user['name'], 'Turkey', equals)
+```
+
+Testing `UPDATE`, including preserving `last_pk` attribute
+
+``` python
+user = users.insert(dict(name='Flamingo', age=12, pwd='pink'))
+user
+```
+
+    {'id': 8, 'name': 'Flamingo', 'age': 12, 'pwd': 'pink'}
+
+``` python
+user = users.update(user['id'], dict(name='Kiwi', pwd='pumpkin'))
+user
+```
+
+    {'id': 7, 'name': 'Kiwi', 'age': 12, 'pwd': 'pumpkin'}
+
+``` python
+test(user['name'], 'Kiwi', equals)
+test(users.last_pk, user['id'], equals)
 ```

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -576,7 +576,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Testing `INSERT`, including preserving `last_pk` attribute"
+    "Testing `INSERT`"
    ]
   },
   {
@@ -613,7 +613,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Testing `UPDATE`, including preserving `last_pk` attribute"
+    "Testing `UPDATE`"
    ]
   },
   {

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -4,16 +4,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#| hide\n",
     "%load_ext autoreload\n",
@@ -582,6 +573,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Testing `INSERT`, including preserving `last_pk` attribute"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -589,7 +587,7 @@
     {
      "data": {
       "text/plain": [
-       "{'id': 8, 'name': 'Turkey', 'age': 2, 'pwd': 'gravy'}"
+       "{'id': 6, 'name': 'Turkey', 'age': 2, 'pwd': 'gravy'}"
       ]
      },
      "execution_count": null,
@@ -609,6 +607,65 @@
    "outputs": [],
    "source": [
     "test(user['name'], 'Turkey', equals)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Testing `UPDATE`, including preserving `last_pk` attribute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 8, 'name': 'Flamingo', 'age': 12, 'pwd': 'pink'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "user = users.insert(dict(name='Flamingo', age=12, pwd='pink'))\n",
+    "user"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 7, 'name': 'Kiwi', 'age': 12, 'pwd': 'pumpkin'}"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "user = users.update(user['id'], dict(name='Kiwi', pwd='pumpkin'))\n",
+    "user"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test(user['name'], 'Kiwi', equals)\n",
+    "test(users.last_pk, user['id'], equals)"
    ]
   }
  ],

--- a/sqlite_minutils/db.py
+++ b/sqlite_minutils/db.py
@@ -2700,7 +2700,7 @@ class Table(Queryable):
         updates: Optional[dict] = None,
         alter: bool = False,
         conversions: Optional[dict] = None,
-    ) -> List[Dict]:
+    ) -> Dict:
         """
         Execute a SQL ``UPDATE`` against the specified row.
 
@@ -2746,14 +2746,12 @@ class Table(Queryable):
             else:
                 raise
 
-        records = []
-        columns = [c[0] for c in cursor.description]
-        record = dict(zip(columns, cursor.fetchone()))
-
         # TODO: Test this works (rolls back) - use better exception:
         # assert rowcount == 1
         self.last_pk = pk_values[0] if len(pks) == 1 else pk_values
-        return record
+
+        columns = [c[0] for c in cursor.description]
+        return dict(zip(columns, cursor.fetchone()))
 
     def build_insert_queries_and_params(
         self,


### PR DESCRIPTION
- Changes the `Table.update()` method to use the RETURNING statement to return the changed record as a `Dict` 
- Adds a test for the change