### PR TITLE
Retry on concurrency issue(s)

### DIFF
--- a/sqlite_minutils/db.py
+++ b/sqlite_minutils/db.py
@@ -9,6 +9,7 @@ import contextlib, datetime, decimal, inspect, itertools, json, os, pathlib, re,
 from typing import ( cast, Any, Callable, Dict, Generator, Iterable, Union, Optional, List, Tuple,)
 from functools import cache
 import uuid
+import time
 
 try: from sqlite_dump import iterdump
 except ImportError: iterdump = None
@@ -426,6 +427,26 @@ class Database:
             yield dict(zip(keys, row))
 
     def execute(
+        self, sql: str, parameters: Optional[Union[Iterable, dict]] = None
+    ) -> sqlite3.Cursor:
+        while True:
+            try:
+                return self._orig_execute(sql=sql, parameters=parameters)   
+            except sqlite3.OperationalError as e:
+                # Catch the unfortunately generic error sqlite3.OperationalError
+                # to determine if this is a concurrency issue
+                if "cannot start a transaction within a transaction" in str(e).lower():
+                    # Probably a concurrency issue, retry
+                    # We could make this more precise with time.perf_counter but
+                    # imprecision here is a good thing as it adds jitter
+                    # Yes, this avoids exponential backoff for REASONS
+                    time.sleep(0.001)
+                    continue
+                # Since this isn't a transaction failure, we re-raise the issue so
+                # other logic in this library can handle it
+                raise
+
+    def _orig_execute(
         self, sql: str, parameters: Optional[Union[Iterable, dict]] = None
     ) -> sqlite3.Cursor:
         """


### PR DESCRIPTION
Using the `patch` pattern from fastai, but without the patch decorator. Wraps the `db.execute()` method to retry on what are probably concurrency issues (need to confirm with new load tests)

Challenge: Unfortunately 

                # Catch the unfortunately generic error sqlite3.OperationalError
                # to determine if this is a concurrency issue
                if "cannot start a transaction within a transaction" in str(e).lower():
                    # Probably a concurrency issue, retry
                    # We could make this more precise with time.perf_counter but
                    # imprecision here is a good thing as it adds jitter
                    # Yes, this avoids exponential backoff for REASONS
                    time.sleep(0.001)
                    continue
                # Since this isn't a transaction failure, we re-raise the issue so
                # other logic in this library can handle it