### PR TITLE
Fixing six tests

### DIFF
--- a/sqlite_minutils/db.py
+++ b/sqlite_minutils/db.py
@@ -1290,7 +1290,7 @@ class Queryable:
             raise ValueError("Cannot use offset without limit")
         if offset is not None:
             sql += f" offset {offset}"
-        cursor = self.db.execute(sql, tuple(where_args or []))
+        cursor = self.db.execute(sql, where_args or [])
         columns = [c[0] for c in cursor.description]
         for row in cursor:
             yield dict(zip(columns, row))
@@ -2941,7 +2941,6 @@ class Table(Queryable):
                 else:
                     raise
             if num_records_processed == 1:
-                # raise Exception
                 if upsert and isinstance(pk, (List, Tuple)) and len(records) == 1:
                     self.last_pk = tuple([y for x,y in records[0].items() if x in pk])
                 elif upsert and hash_id and len(records) > 0:

--- a/sqlite_minutils/db.py
+++ b/sqlite_minutils/db.py
@@ -2760,6 +2760,9 @@ class Table(Queryable):
         replace,
         ignore,
     ):
+        # Caching of table converted conversions from a dict to a tuple. Convert it back
+        if isinstance(conversions, Tuple): conversions = dict(conversions)
+
         # values is the list of insert data that is passed to the
         # .execute() method - but some of them may be replaced by
         # new primary keys if we are extracting any columns.


### PR DESCRIPTION
This pull request fixes six of nine remaining broken tests. Notes:L

1. Brings in `RETURNING *` in order for some of the tests to pass. 
2. Works around that sqlite-minutils expects to use last_rowid, including in places with compound primary keys cannot work with last_rowid
3. Removing unnecessary tuple conversion for `where_args`
4. Added logic to handle the conversion of `conversions` back from a tuple to a dictionary in `build_insert_queries_and_params`. We don't do it in the init, as that may cause problems for caching of the table

If it makes it easier to review, this can be broken up into multiple PRs.
